### PR TITLE
Section 6.8. Connection Collision Detection compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
+compile_commands.json
+.cache/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(trip)
 
@@ -12,6 +12,8 @@ file(GLOB COMMAND_SRC "src/command/*.c")
 file(GLOB LOGGING_SRC "src/logging/*.c")
 file(GLOB UTIL_SRC "src/util/*.c")
 file(GLOB TRIPD_SRC "src/tripd/*.c")
+
+add_compile_options(-Wall -Wextra -Wno-pedantic -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable)
 
 add_library(logging STATIC ${LOGGING_SRC})
 
@@ -26,7 +28,6 @@ target_link_libraries(functions protocol logging util)
 add_library(command STATIC ${COMMAND_SRC})
 target_link_libraries(command functions logging)
 
-
 add_executable(tripd ${TRIPD_SRC})
 target_link_libraries(tripd command)
 
@@ -39,7 +40,7 @@ if (DOXYGEN)
     configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
     add_custom_target(documentation ALL
-        COMMAND ${DOXYGEN} ${DOXYGEN_OUT}
+        COMMAND ${DOXYGEN} ${DOXYGEN_OUT} 2>&1 > ${CMAKE_CURRENT_BINARY_DIR}/doxygen.log
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         VERBATIM)
 else (DOXYGEN_FOUND)

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -852,7 +852,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as documenting some parameters in

--- a/src/functions/locator.c
+++ b/src/functions/locator.c
@@ -43,7 +43,7 @@ locator_new()
     return &g_locator;
 }
 
-int
+const peer_t *
 locator_add(locator_t *locator, const struct sockaddr_in6 *addr,
     uint32_t itad, uint16_t hold, capinfo_transmode_t transmode)
 {
@@ -53,18 +53,17 @@ locator_add(locator_t *locator, const struct sockaddr_in6 *addr,
             locator->peers_capacity * sizeof(peer_t));
     }
 
-    peer_t *peer = &locator->peers[locator->peers_size++];
-    memcpy(&peer->addr, addr, sizeof(struct sockaddr_in6));
-    peer->itad = itad;
-    peer->hold = hold;
-    peer->transmode = transmode;
+    peer_t *p= &locator->peers[locator->peers_size++];
+    memcpy(&p->addr, addr, sizeof(struct sockaddr_in6));
+    p->itad = itad;
+    p->hold = hold;
+    p->transmode = transmode;
     
-    return locator->peers_size - 1;
+    return p;
 }
 
-int
-locator_lookup(locator_t *locator, const peer_t **peer,
-    const struct sockaddr_in6 *addr)
+const peer_t *
+locator_lookup(locator_t *locator, const struct sockaddr_in6 *addr)
 {
     peer_t *p = NULL;
     size_t i = 0;
@@ -78,8 +77,7 @@ locator_lookup(locator_t *locator, const peer_t **peer,
         }
     }
 
-    *peer = p;
-    return p ? (int)i : -1;
+    return p;
 }
 
 
@@ -90,5 +88,4 @@ locator_destroy(locator_t *locator)
         return;
     free(locator->peers);
 }
-
 

--- a/src/functions/locator.h
+++ b/src/functions/locator.h
@@ -51,11 +51,11 @@ typedef struct {
 locator_t *locator_new();
 
 /** \brief Add a known peer */
-int locator_add(locator_t *locator, const struct sockaddr_in6 *addr,
+const peer_t *locator_add(locator_t *locator, const struct sockaddr_in6 *addr,
     uint32_t itad, uint16_t hold, capinfo_transmode_t transmode);
 
 /** \brief Lookup peer by its address */
-int locator_lookup(locator_t *locator, const peer_t **peer,
+const peer_t *locator_lookup(locator_t *locator,
     const struct sockaddr_in6 *addr);
 
 /** \brief Destroy locator object */

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -112,8 +112,25 @@ send_notification_res(int fd, int res)
 
 
 
+/** \brief Remove session from */
+static void
+manager_session_remove(manager_t *manager, session_t *session)
+{
+    int s_idx = -1;
+    for (int i = 0; i < manager->sessions_size; i++)
+        if (manager->sessions[i] == session)
+            s_idx = i;
+
+    session_destroy(session);
+    memcpy(&manager->sessions[s_idx], &manager->sessions[s_idx + 1],
+        manager->sessions_size - s_idx);
+    manager->sessions_size--;
+}
+
+
 /* =================== REQUEST HANDLING ===================================== */
 
+/** \brief Handle a received OPEN message (OpenConfirm State) */
 static int
 handle_open(manager_t *m, session_t *s, const msg_t *msg,
     void *recv_wnd)
@@ -139,39 +156,15 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
         return -1;
     }
 
-    /* collision detection of established sessions RFC section 6.8 */
-    session_t *coll_s = manager_lookup_session_itad_id(m, open->open_itad,
-        open->open_id);
-    if (coll_s) {
-        ERROR("peer itad,id (%d,%d) collission: old peer %s, new peer %s",
-            open->open_itad, open->open_id,
-            sockaddr6_str(coll_s->addr), sockaddr6_str(s->addr));
-        send_notification(s->fd, NOTIF_CODE_CEASE, 0);
+    /* duplicate ID in ITAD peer collision detection */
+    if ((open->open_itad == m->itad) && (open->open_id == m->id)) {
+        ERROR("duplicate ID in ITAD detected, colliding peer rejected");
+        send_notification(s->fd, NOTIF_CODE_ERROR_OPEN,
+            NOTIF_SUBCODE_OPEN_BAD_ID);
         return -1;
     }
 
-    coll_s = manager_lookup_session_id(m, open->open_id);
-    if (coll_s) {
-        WARNING("collission detected with id %d at %s", coll_s->peer_id,
-            sockaddr6_str(s->addr));
-        send_notification(s->fd, NOTIF_CODE_CEASE, 0);
-        return -1;
-    }
-
-    /* TODO: collision detection with pre-session requests */
-#if 0
-    request_t *coll_r = manager_lookup_request_id(m, open->open_id);
-    if (coll_s) {
-        WARNING("collission detected");
-        if ((m->id < open->open_id) ||
-            (m->id == open->open_id) && (m->itad < open->open_itad))
-        {
-            send_notification(coll_s->fd, NOTIF_CODE_CEASE, 0);
-            session_shutdown(coll_s);
-        } else
-            return -1;
-    }
-#endif
+    /* TODO: section 6.8 collision detection */
 
     s->peer_id = open->open_id;
     s->hold = MIN(s->peer->hold, open->open_hold);

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -226,7 +226,6 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
                 /* cease, close and destroy old session, remove from vector */
                 send_notification(coll_s->fd, NOTIF_CODE_CEASE, 0);
                 session_shutdown(coll_s);
-                session_destroy(coll_s);
                 manager_session_remove(m, coll_s);
             }
         } else if (coll_s->state == STATE_ESTABLISHED) {
@@ -241,7 +240,6 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
     if (init_s) {
         INFO("closing old initiating session");
         session_shutdown(init_s);
-        session_destroy(init_s);
         manager_session_remove(m, init_s);
     }
 

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -32,7 +32,10 @@
 #include "manager.h"
 
 #include "locator.h"
+#include "logging/logging.h"
+#include "protocol/protocol.h"
 #include "session.h"
+#include "util/util.h"
 
 #include <logging/logging.c>
 #include <util/util.c>
@@ -55,38 +58,48 @@
 #endif /* MAX_BACKOFF_CONNECT_RETRY */
 
 
-typedef struct {
-    manager_t              *manager;
 
-    pthread_t               thread;
-    int                     peer_idx;
-    struct sockaddr_in6    *addr;
-    int                     fd;
-    session_state_t         state;
-
-    /* discovered */
-    uint32_t                id;
-    uint32_t                hold;
-} request_t;
-
-
+/** \brief Change request state */
 static void
-request_change_state(request_t *r, session_state_t new_state)
+request_change_state(manager_t *m, request_t *r, session_state_t new_state)
 {
     char abuff[INET6_ADDRSTRLEN];
     DEBUG("peer (%s):%d request changed state from %s to %s",
         inet_ntop(AF_INET6, &r->addr->sin6_addr, abuff,
             sizeof(abuff)),
-        r->manager->locator->peers[r->peer_idx].itad,
+        m->locator->peers[r->peer_idx].itad,
         session_state_strs[r->state], session_state_strs[new_state]);
 
     r->state = new_state;
 }
 
+/** \brief Lookup session by ITAD and ID match */
+session_t *
+manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
+    uint32_t id)
+{
+    for (size_t i = 0; i < manager->sessions_size; i++)
+        if (manager->sessions[i]->itad == itad &&
+            manager->sessions[i]->id == id)
+        {
+            return manager->sessions[i];
+        }
+    return NULL;
+}
 
-/** /brief for OPEN handler
+/** \brief Lookup session by ID match */
+session_t *
+manager_lookup_session_id(manager_t *manager, uint32_t id)
+{
+    for (size_t i = 0; i < manager->sessions_size; i++)
+        if (manager->sessions[i]->itad == id)
+            return manager->sessions[i];
+    return NULL;
+}
+
+/** \brief Send notification corresponding to protocol error
  *
- * only if res warrants a NOTIFICATION
+ * for OPEN handler, only send if res warrants a NOTIFICATION
  */
 static int
 send_notification_res(int fd, int res)
@@ -116,7 +129,8 @@ send_notification_res(int fd, int res)
 /* =================== REQUEST HANDLING ===================================== */
 
 static int
-handle_open(request_t *r, const peer_t *peer, const msg_t *msg, void *recv_wnd)
+handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
+    void *recv_wnd)
 {
     int res = 0, toread = 0;
     SOCK_TRY_RECV(r->fd, recv_wnd, msg_open_t, goto sock_error);
@@ -139,13 +153,39 @@ handle_open(request_t *r, const peer_t *peer, const msg_t *msg, void *recv_wnd)
         return -1;
     }
 
-    /* TODO: collision detection as per RFC
-    if (manager_lookup_itad_id(s->itad, open->open_id)) {
-        ERROR("peer ID exists in same ITAD");
-        send_notification(s, NOTIF_CODE_ERROR_OPEN,
-            NOTIF_SUBCODE_OPEN_BAD_ID);
+    /* collision detection of established sessions RFC section 6.8 */
+    session_t *coll_s = manager_lookup_session_itad_id(m, open->open_itad,
+        open->open_id);
+    if (coll_s) {
+        ERROR("peer itad,id (%d,%d) collission: old peer %s, new peer %s",
+            open->open_itad, open->open_id,
+            sockaddr6_str(coll_s->addr), sockaddr6_str(&peer->addr));
+        send_notification(r->fd, NOTIF_CODE_CEASE, 0);
         return -1;
-    } */
+    }
+
+    coll_s = manager_lookup_session_id(m, open->open_id);
+    if (coll_s) {
+        WARNING("collission detected with id %d at %s", coll_s->id,
+            sockaddr6_str(r->addr));
+        send_notification(r->fd, NOTIF_CODE_CEASE, 0);
+        return -1;
+    }
+
+    /* TODO: collision detection with pre-session requests */
+#if 0
+    request_t *coll_r = manager_lookup_request_id(m, open->open_id);
+    if (coll_s) {
+        WARNING("collission detected");
+        if ((m->id < open->open_id) ||
+            (m->id == open->open_id) && (m->itad < open->open_itad))
+        {
+            send_notification(coll_s->fd, NOTIF_CODE_CEASE, 0);
+            session_shutdown(coll_s);
+        } else
+            return -1;
+    }
+#endif
 
     r->id = open->open_id;
     r->hold = MIN(peer->hold, open->open_hold);
@@ -270,17 +310,18 @@ sock_error:
 static void *
 peer_handshake(void *arg)
 {
-    request_t *req = arg;
+    manager_t *m = ((void**)arg)[0];
+    request_t *req = ((void**)arg)[1];
 
     int res = 0, toread = 0;
     char buff[MAX_MSG_SIZE];
 
-    const peer_t *peer = &req->manager->locator->peers[req->peer_idx];
+    const peer_t *peer = &m->locator->peers[req->peer_idx];
 
     /* send OPEN */
     PROTO_TRY(
         new_msg_open(buff, MAX_MSG_SIZE,
-            peer->hold, req->manager->itad, req->manager->id,
+            peer->hold, m->itad, m->id,
             supported_routetypes, supported_routetypes_size,
             peer->transmode),
         res, goto proto_error
@@ -290,7 +331,7 @@ peer_handshake(void *arg)
         send(req->fd, buff, res, 0),
         goto sock_error
     );
-    request_change_state(req, STATE_OPENSENT);
+    request_change_state(m, req, STATE_OPENSENT);
 
 
     /* receive OPEN */
@@ -310,7 +351,7 @@ peer_handshake(void *arg)
 
         switch (msg->msg_type) {
         case MSG_TYPE_OPEN: {
-            if (handle_open(req, peer, msg, recv_wnd) < 0)
+            if (handle_open(m, req, peer, msg, recv_wnd) < 0)
                 goto sock_error;
 
             PROTO_TRY(
@@ -323,7 +364,7 @@ peer_handshake(void *arg)
                 goto sock_error
             );
 
-            request_change_state(req, STATE_OPENCONFIRM);
+            request_change_state(m, req, STATE_OPENCONFIRM);
         } break;
         case MSG_TYPE_NOTIFICATION: {
             SOCK_TRY_RECV(req->fd, recv_wnd, msg_notif_t, goto sock_error);
@@ -341,7 +382,7 @@ peer_handshake(void *arg)
         } break;
         case MSG_TYPE_KEEPALIVE: {
             if (req->state == STATE_OPENCONFIRM)
-                request_change_state(req, STATE_ESTABLISHED);
+                request_change_state(m, req, STATE_ESTABLISHED);
 
             /* create session, insert session into sessions
              * hand off to session loop, free request
@@ -351,15 +392,15 @@ peer_handshake(void *arg)
             session->thread = req->thread;
             session->fd = req->fd;
             session->state = STATE_IDLE;
-            session->itad = req->manager->itad;
-            session->id = req->manager->id;
+            session->itad = m->itad;
+            session->id = m->id;
             session->hold = req->hold;
             session->transmode = peer->transmode;
             session->addr = req->addr;
             session->peer_itad = peer->itad;
             session->peer_id = req->id;
 
-            req->manager->sessions[req->peer_idx] = session;
+            m->sessions[req->peer_idx] = session;
 
             free(req);
 
@@ -377,7 +418,7 @@ proto_error:
 
 sock_error:
     close(req->fd);
-    request_change_state(req, STATE_IDLE);
+    request_change_state(m, req, STATE_IDLE);
     free(req->addr);
     free(req);
     return NULL;
@@ -426,13 +467,16 @@ manager_loop(void *arg)
 
         /* hand off connection to request handler on a new thread */
         request_t *req = malloc(sizeof(request_t));
-        req->manager = m;
         req->peer_idx = idx;
         req->addr = malloc(peer_addr_size);
         memcpy(req->addr, &peer_addr, peer_addr_size);
         req->fd = request_fd;
 
-        pthread_create(&req->thread, NULL, &peer_handshake, req);
+        void **handshake_data = malloc(2 * sizeof(void*));
+        handshake_data[0] = m;
+        handshake_data[1] = req;
+
+        pthread_create(&req->thread, NULL, &peer_handshake, handshake_data);
         pthread_detach(req->thread);
     }
 
@@ -457,6 +501,9 @@ manager_new(const struct sockaddr_in6 *listen_addr)
     m->locator = locator_new();
 
     m->sessions = malloc(m->locator->peers_size * sizeof(session_t*));
+    memset(m->sessions, 0, m->locator->peers_size * sizeof(session_t*));
+
+    m->requests = malloc(4 * sizeof(request_t*));
     memset(m->sessions, 0, m->locator->peers_size * sizeof(session_t*));
 
     /* create listen socket */
@@ -493,12 +540,13 @@ manager_new(const struct sockaddr_in6 *listen_addr)
 static void *
 connect_loop(void *arg)
 {
-    request_t *req = arg;
+    manager_t *m = ((void**)arg)[0];
+    request_t *req = ((void**)arg)[1];
     time_t connect_retry = 120;
 
     int r = 0;
     while (1) {
-        request_change_state(req, STATE_CONNECT);
+        request_change_state(m, req, STATE_CONNECT);
 
         int res = connect(req->fd,
             (struct sockaddr*)req->addr,
@@ -506,7 +554,7 @@ connect_loop(void *arg)
 
         if (res < 0) {
             ERROR("connect(): %s", strerror(errno));
-            request_change_state(req, STATE_IDLE);
+            request_change_state(m, req, STATE_IDLE);
             sleep(connect_retry);
             if (connect_retry < MAX_BACKOFF_CONNECT_RETRY)
                 connect_retry *= 2;
@@ -518,6 +566,7 @@ connect_loop(void *arg)
 
     /* TCP channel established, hand off to request handler */
     peer_handshake(arg);
+    return NULL;
 }
 
 
@@ -539,7 +588,6 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
 
     /* create session request object and hand off to connect loop */
     request_t *req = malloc(sizeof(request_t));
-    req->manager = manager;
     req->peer_idx = idx;
     req->addr = malloc(sizeof(struct sockaddr_in6));
     memcpy(req->addr, addr, sizeof(struct sockaddr_in6));
@@ -547,7 +595,12 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
 
     req->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
     
-    pthread_create(&req->thread, NULL, &connect_loop, req);
+
+    void **connect_data = malloc(2 * sizeof(void*));
+    connect_data[0] = manager;
+    connect_data[1] = req;
+
+    pthread_create(&req->thread, NULL, &connect_loop, connect_data);
 }
 
 void

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -60,7 +60,7 @@
 
 
 /** \brief Lookup session by ITAD and ID match */
-session_t *
+static session_t *
 manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
     uint32_t id)
 {
@@ -70,16 +70,6 @@ manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
         {
             return manager->sessions[i];
         }
-    return NULL;
-}
-
-/** \brief Lookup session by ID match */
-session_t *
-manager_lookup_session_id(manager_t *manager, uint32_t id)
-{
-    for (size_t i = 0; i < manager->sessions_size; i++)
-        if (manager->sessions[i]->peer_id == id)
-            return manager->sessions[i];
     return NULL;
 }
 
@@ -110,23 +100,68 @@ send_notification_res(int fd, int res)
     return 0;
 }
 
-
-
-/** \brief Remove session from */
+/** \brief Add session to manager */
 static void
-manager_session_remove(manager_t *manager, session_t *session)
+manager_session_add(manager_t *m, session_t *s)
 {
-    int s_idx = -1;
-    for (int i = 0; i < manager->sessions_size; i++)
-        if (manager->sessions[i] == session)
-            s_idx = i;
+    if (m->sessions_size + 1 > m->sessions_capacity) {
+        m->sessions = realloc(m->sessions,
+            2 * sizeof(session_t) * m->sessions_capacity);
+        m->sessions_capacity *= 2;
+    }
 
-    session_destroy(session);
-    memcpy(&manager->sessions[s_idx], &manager->sessions[s_idx + 1],
-        manager->sessions_size - s_idx);
-    manager->sessions_size--;
+    m->sessions[m->sessions_size++] = s;
 }
 
+/** \brief Remove session from manager */
+static void
+manager_session_remove(manager_t *m, session_t *s)
+{
+    int s_idx = -1;
+    for (int i = 0; i < m->sessions_size; i++)
+        if (m->sessions[i] == s)
+            s_idx = i;
+
+    session_destroy(s);
+    memcpy(&m->sessions[s_idx], &m->sessions[s_idx + 1],
+        m->sessions_size - s_idx);
+    m->sessions_size--;
+}
+
+/** \brief Compare two ITAD,ID pairs
+ *
+ * \return non-zero if pair 1 < pair 2, zero if otherwise
+ */
+static int
+compare_itad_id(uint32_t itad1, uint32_t id1, uint32_t itad2, uint32_t id2)
+{
+    return (id1 < id2) || (id1 == id2 && (itad1 < itad2));
+}
+
+/** \brief Compare two colliding sessions
+ *
+ * \return non-zero if s1 should be closed, zero if s2 should be closed
+ *
+ * \param s1 New session
+ * \param s2 Old session
+ */
+static int
+manager_collision_sessions_compare(const manager_t *m, const session_t *s1,
+    const session_t *s2)
+{
+    if (s1->initiated == s2->initiated) {
+        ERROR("colliding connections initiated by same ID");
+        return 1;
+    } else if (s1->initiated) {
+        /* new session initiated by local
+         * return local < s2 peer */
+        return compare_itad_id(m->itad, m->id, s2->peer->itad, s2->peer_id);
+    } else {
+        /* old connection initiated by local
+         * return s1 peer < local */
+        return compare_itad_id(s1->peer->itad, s1->peer_id, m->itad, m->id);
+    }
+}
 
 /* =================== REQUEST HANDLING ===================================== */
 
@@ -164,10 +199,36 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
         return -1;
     }
 
-    /* TODO: section 6.8 collision detection */
+    /* section 6.8 collision detection */
+    session_t *coll_s = manager_lookup_session_itad_id(m, open->open_itad,
+        open->open_id);
+
+    if (coll_s) {
+        WARNING("collision detected with peer (%d,%d)", open->open_itad,
+            open->open_id);
+        if (coll_s->state == STATE_OPENCONFIRM) {
+            WARNING("collision resolved: kept higher ID or ITAD");
+            if (manager_collision_sessions_compare(m, s, coll_s)) {
+                send_notification(s->fd, NOTIF_CODE_CEASE, 0);
+                return -1;
+            } else {
+                send_notification(coll_s->fd, NOTIF_CODE_CEASE, 0);
+                session_shutdown(coll_s);
+                session_destroy(coll_s);
+                manager_session_remove(m, coll_s);
+            }
+        } else if (coll_s->state == STATE_ESTABLISHED) {
+            WARNING("collision resolved: kept established connection");
+            send_notification(s->fd, NOTIF_CODE_CEASE, 0);
+            return -1;
+        }
+    }
 
     s->peer_id = open->open_id;
     s->hold = MIN(s->peer->hold, open->open_hold);
+
+    /* now add session to manager */
+    manager_session_add(m, s);
 
     size_t opts_toread = open->open_opts_len;
     const void *opt_cur = open->open_opts;
@@ -417,13 +478,14 @@ manager_loop(void *arg)
             sockaddr_str((struct sockaddr*)&peer_addr));
 
 
-        /* hand off connection to request handler on a new thread */
+        /* hand off connection to handshake handler on a new thread */
         session_t *s = malloc(sizeof(session_t));
         memset(s, 0, sizeof(session_t));
         s->peer = peer;
         s->addr = malloc(peer_addr_size);
         memcpy(s->addr, &peer_addr, peer_addr_size);
         s->fd = request_fd;
+        s->initiated = 0;
 
         void **handshake_data = malloc(2 * sizeof(void*));
         handshake_data[0] = m;
@@ -539,22 +601,17 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
         return;
     }
 
-    /* create session request object and hand off to connect loop */
+    /* create session object and hand off to connect loop */
     session_t *s = malloc(sizeof(session_t));
     memset(s, 0, sizeof(session_t));
     s->peer = peer;
     s->addr = malloc(sizeof(struct sockaddr_in6));
     memcpy(s->addr, addr, sizeof(struct sockaddr_in6));
     s->state = STATE_IDLE;
+    s->initiated = 1;
 
     /* add session to manager session vector */
-    if (manager->sessions_size + 1 > manager->sessions_capacity) {
-        manager->sessions = realloc(manager->sessions,
-            2 * sizeof(session_t) * manager->sessions_capacity);
-        manager->sessions_capacity *= 2;
-    }
-
-    manager->sessions[manager->sessions_size++] = s;
+    manager_session_add(manager, s);
 
     /* create socket and pass session to connect loop */
     s->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -449,6 +449,9 @@ peer_handshake(void *arg)
 
             /* Hand newly established session off to session_loop */
             session_loop(arg);
+
+            /* If peer disconnects going back to idle, start connect loop */
+            s->initiated = 1;
             connect_loop(arg);
         } break;
         default:

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -61,14 +61,26 @@
 
 /** \brief Lookup session by ITAD and ID match */
 static session_t *
-manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
+manager_session_lookup_itad_id(manager_t *m, uint32_t itad,
     uint32_t id)
 {
-    for (size_t i = 0; i < manager->sessions_size; i++)
-        if (manager->sessions[i]->peer->itad == itad &&
-            manager->sessions[i]->peer_id == id)
+    for (size_t i = 0; i < m->sessions_size; i++)
+        if (m->sessions[i]->peer->itad == itad &&
+            m->sessions[i]->peer_id == id)
         {
-            return manager->sessions[i];
+            return m->sessions[i];
+        }
+    return NULL;
+}
+
+/** \brief Lookup session by locator peer */
+static session_t *
+manager_session_lookup_peer(manager_t *m, const peer_t *peer)
+{
+    for (size_t i = 0; i < m->sessions_size; i++)
+        if (m->sessions[i]->peer == peer)
+        {
+            return m->sessions[i];
         }
     return NULL;
 }
@@ -200,9 +212,8 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
     }
 
     /* section 6.8 collision detection */
-    session_t *coll_s = manager_lookup_session_itad_id(m, open->open_itad,
+    session_t *coll_s = manager_session_lookup_itad_id(m, open->open_itad,
         open->open_id);
-
     if (coll_s) {
         WARNING("collision detected with peer (%d,%d)", open->open_itad,
             open->open_id);
@@ -212,6 +223,7 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
                 send_notification(s->fd, NOTIF_CODE_CEASE, 0);
                 return -1;
             } else {
+                /* cease, close and destroy old session, remove from vector */
                 send_notification(coll_s->fd, NOTIF_CODE_CEASE, 0);
                 session_shutdown(coll_s);
                 session_destroy(coll_s);
@@ -223,6 +235,16 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
             return -1;
         }
     }
+
+    /* find old still initiating session pre-openconfirm if exists and stop it*/
+    session_t *init_s = manager_session_lookup_peer(m, s->peer);
+    if (init_s) {
+        INFO("closing old initiating session");
+        session_shutdown(init_s);
+        session_destroy(init_s);
+        manager_session_remove(m, init_s);
+    }
+
 
     s->peer_id = open->open_id;
     s->hold = MIN(s->peer->hold, open->open_hold);

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -59,28 +59,14 @@
 
 
 
-/** \brief Change request state */
-static void
-request_change_state(manager_t *m, request_t *r, session_state_t new_state)
-{
-    char abuff[INET6_ADDRSTRLEN];
-    DEBUG("peer (%s):%d request changed state from %s to %s",
-        inet_ntop(AF_INET6, &r->addr->sin6_addr, abuff,
-            sizeof(abuff)),
-        m->locator->peers[r->peer_idx].itad,
-        session_state_strs[r->state], session_state_strs[new_state]);
-
-    r->state = new_state;
-}
-
 /** \brief Lookup session by ITAD and ID match */
 session_t *
 manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
     uint32_t id)
 {
     for (size_t i = 0; i < manager->sessions_size; i++)
-        if (manager->sessions[i]->itad == itad &&
-            manager->sessions[i]->id == id)
+        if (manager->sessions[i]->peer->itad == itad &&
+            manager->sessions[i]->peer_id == id)
         {
             return manager->sessions[i];
         }
@@ -92,7 +78,7 @@ session_t *
 manager_lookup_session_id(manager_t *manager, uint32_t id)
 {
     for (size_t i = 0; i < manager->sessions_size; i++)
-        if (manager->sessions[i]->itad == id)
+        if (manager->sessions[i]->peer_id == id)
             return manager->sessions[i];
     return NULL;
 }
@@ -129,11 +115,11 @@ send_notification_res(int fd, int res)
 /* =================== REQUEST HANDLING ===================================== */
 
 static int
-handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
+handle_open(manager_t *m, session_t *s, const msg_t *msg,
     void *recv_wnd)
 {
     int res = 0, toread = 0;
-    SOCK_TRY_RECV(r->fd, recv_wnd, msg_open_t, goto sock_error);
+    SOCK_TRY_RECV(s->fd, recv_wnd, msg_open_t, goto sock_error);
 
     const msg_open_t *open = NULL;
     PROTO_TRY(
@@ -146,9 +132,9 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
         id_str(open->open_id), open->open_opts_len);
 
     /* check received OPEN fields */
-    if (open->open_itad != peer->itad) {
+    if (open->open_itad != s->peer->itad) {
         ERROR("peer ITAD mismatch");
-        send_notification(r->fd, NOTIF_CODE_ERROR_OPEN,
+        send_notification(s->fd, NOTIF_CODE_ERROR_OPEN,
             NOTIF_SUBCODE_OPEN_BAD_ITAD);
         return -1;
     }
@@ -159,16 +145,16 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
     if (coll_s) {
         ERROR("peer itad,id (%d,%d) collission: old peer %s, new peer %s",
             open->open_itad, open->open_id,
-            sockaddr6_str(coll_s->addr), sockaddr6_str(&peer->addr));
-        send_notification(r->fd, NOTIF_CODE_CEASE, 0);
+            sockaddr6_str(coll_s->addr), sockaddr6_str(s->addr));
+        send_notification(s->fd, NOTIF_CODE_CEASE, 0);
         return -1;
     }
 
     coll_s = manager_lookup_session_id(m, open->open_id);
     if (coll_s) {
-        WARNING("collission detected with id %d at %s", coll_s->id,
-            sockaddr6_str(r->addr));
-        send_notification(r->fd, NOTIF_CODE_CEASE, 0);
+        WARNING("collission detected with id %d at %s", coll_s->peer_id,
+            sockaddr6_str(s->addr));
+        send_notification(s->fd, NOTIF_CODE_CEASE, 0);
         return -1;
     }
 
@@ -187,13 +173,13 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
     }
 #endif
 
-    r->id = open->open_id;
-    r->hold = MIN(peer->hold, open->open_hold);
+    s->peer_id = open->open_id;
+    s->hold = MIN(s->peer->hold, open->open_hold);
 
     size_t opts_toread = open->open_opts_len;
     const void *opt_cur = open->open_opts;
     while (opts_toread) {
-        SOCK_TRY_RECV(r->fd, recv_wnd, msg_open_opt_t,
+        SOCK_TRY_RECV(s->fd, recv_wnd, msg_open_opt_t,
             goto sock_error);
 
         const msg_open_opt_t *opt = NULL;
@@ -212,7 +198,7 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
             size_t capinfos_toread = opt->opt_len;
             const void *capinfo_cur = opt->opt_val;
             while (capinfos_toread) {
-                SOCK_TRY_RECV(r->fd, recv_wnd, capinfo_t,
+                SOCK_TRY_RECV(s->fd, recv_wnd, capinfo_t,
                     goto sock_error);
 
                 const capinfo_t *capinfo = NULL;
@@ -234,7 +220,7 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
                     size_t routetypes_toread = capinfo->capinfo_len;
                     const void *routetype_cur = capinfo->capinfo_val;
                     while (routetypes_toread) {
-                        SOCK_TRY_RECV(r->fd, recv_wnd,
+                        SOCK_TRY_RECV(s->fd, recv_wnd,
                             capinfo_routetype_t, goto sock_error);
 
                         const capinfo_routetype_t *routetype = NULL;
@@ -256,7 +242,7 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
                     }
                 } break;
                 case CAPINFO_CODE_TRANSMODE: {
-                    SOCK_TRY_RECV(r->fd, recv_wnd,
+                    SOCK_TRY_RECV(s->fd, recv_wnd,
                         capinfo_transmode_t, goto sock_error);
 
                     const capinfo_transmode_t *transmode = NULL;
@@ -273,9 +259,10 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
                         capinfo_transmode_strs[*transmode]);
 
                     if (*transmode != CAPINFO_TRANS_SEND_RECV &&
-                        (*transmode == peer->transmode))
+                        (*transmode == s->peer->transmode))
                     {
-                        send_notification(r->fd, NOTIF_CODE_ERROR_OPEN,
+                        WARNING("    transmission mode mismatch");
+                        send_notification(s->fd, NOTIF_CODE_ERROR_OPEN,
                             NOTIF_SUBCODE_OPEN_CAP_MISMATCH);
                         return -1;
                     }
@@ -294,7 +281,7 @@ handle_open(manager_t *m, request_t *r, const peer_t *peer, const msg_t *msg,
     return 0;
 
 proto_error:
-    send_notification_res(r->fd, res);
+    send_notification_res(s->fd, res);
 
 sock_error:
     return -1;
@@ -306,39 +293,39 @@ sock_error:
  * Send OPEN, listen for OPEN, decode OPEN, check fields against peers,
  * send KEEPALIVE, receive KEEPALIVE, established the session -> hand off to
  * session loop
+ *
+ * \param arg Of type (void*){ manager_t *m, session_t *s }
  */
 static void *
 peer_handshake(void *arg)
 {
     manager_t *m = ((void**)arg)[0];
-    request_t *req = ((void**)arg)[1];
+    session_t *s = ((void**)arg)[1];
 
     int res = 0, toread = 0;
     char buff[MAX_MSG_SIZE];
 
-    const peer_t *peer = &m->locator->peers[req->peer_idx];
-
     /* send OPEN */
     PROTO_TRY(
         new_msg_open(buff, MAX_MSG_SIZE,
-            peer->hold, m->itad, m->id,
+            s->peer->hold, m->itad, m->id,
             supported_routetypes, supported_routetypes_size,
-            peer->transmode),
+            s->peer->transmode),
         res, goto proto_error
     );
 
     SOCK_TRY_SEND(
-        send(req->fd, buff, res, 0),
+        send(s->fd, buff, res, 0),
         goto sock_error
     );
-    request_change_state(m, req, STATE_OPENSENT);
+    session_change_state(s, STATE_OPENSENT);
 
 
     /* receive OPEN */
     while (1) {
         void *recv_wnd = buff;
         /* receive and decode message header */
-        SOCK_TRY_RECV(req->fd, recv_wnd, msg_t, goto sock_error);
+        SOCK_TRY_RECV(s->fd, recv_wnd, msg_t, goto sock_error);
 
         const msg_t *msg = NULL;
         PROTO_TRY(
@@ -351,7 +338,7 @@ peer_handshake(void *arg)
 
         switch (msg->msg_type) {
         case MSG_TYPE_OPEN: {
-            if (handle_open(m, req, peer, msg, recv_wnd) < 0)
+            if (handle_open(m, s, msg, recv_wnd) < 0)
                 goto sock_error;
 
             PROTO_TRY(
@@ -360,14 +347,14 @@ peer_handshake(void *arg)
             );
 
             SOCK_TRY_SEND(
-                send(req->fd, buff, res, 0),
+                send(s->fd, buff, res, 0),
                 goto sock_error
             );
 
-            request_change_state(m, req, STATE_OPENCONFIRM);
+            session_change_state(s, STATE_OPENCONFIRM);
         } break;
         case MSG_TYPE_NOTIFICATION: {
-            SOCK_TRY_RECV(req->fd, recv_wnd, msg_notif_t, goto sock_error);
+            SOCK_TRY_RECV(s->fd, recv_wnd, msg_notif_t, goto sock_error);
 
             const msg_notif_t *notif= NULL;
             PROTO_TRY(
@@ -381,30 +368,12 @@ peer_handshake(void *arg)
                     [notif->notif_error_subcode]);
         } break;
         case MSG_TYPE_KEEPALIVE: {
-            if (req->state == STATE_OPENCONFIRM)
-                request_change_state(m, req, STATE_ESTABLISHED);
+            if (s->state == STATE_OPENCONFIRM)
+                session_change_state(s, STATE_ESTABLISHED);
 
-            /* create session, insert session into sessions
-             * hand off to session loop, free request
-             * no constructor because it only occurs here and would be
-             * cumbersome */
-            session_t *session = malloc(sizeof(session_t));
-            session->thread = req->thread;
-            session->fd = req->fd;
-            session->state = STATE_IDLE;
-            session->itad = m->itad;
-            session->id = m->id;
-            session->hold = req->hold;
-            session->transmode = peer->transmode;
-            session->addr = req->addr;
-            session->peer_itad = peer->itad;
-            session->peer_id = req->id;
-
-            m->sessions[req->peer_idx] = session;
-
-            free(req);
-
-            session_loop(session);
+            /* Hand newly established session off to session_loop */
+            session_loop(arg);
+            return NULL;
         } break;
         default:
             ERROR("unexpected %s message");
@@ -414,13 +383,11 @@ peer_handshake(void *arg)
 
 
 proto_error:
-    send_notification_res(req->fd, res);
+    send_notification_res(s->fd, res);
 
 sock_error:
-    close(req->fd);
-    request_change_state(m, req, STATE_IDLE);
-    free(req->addr);
-    free(req);
+    close(s->fd);
+    session_change_state(s, STATE_IDLE);
     return NULL;
 }
 
@@ -445,17 +412,9 @@ manager_loop(void *arg)
 
         /* check that connection comes from peer, and that this peer does not
          * have an active session */
-        const peer_t *peer = NULL;
-        int idx = locator_lookup(m->locator, &peer, &peer_addr);
+        const peer_t *peer = locator_lookup(m->locator, &peer_addr);
         if (!peer) {
             INFO("rejecting unknown peer connection: %s",
-                sockaddr_str((struct sockaddr *)&peer_addr));
-            close(request_fd);
-            continue;
-        }
-
-        if (m->sessions[idx]) {
-            INFO("rejecting existing peer connection: %s",
                 sockaddr_str((struct sockaddr *)&peer_addr));
             close(request_fd);
             continue;
@@ -466,18 +425,19 @@ manager_loop(void *arg)
 
 
         /* hand off connection to request handler on a new thread */
-        request_t *req = malloc(sizeof(request_t));
-        req->peer_idx = idx;
-        req->addr = malloc(peer_addr_size);
-        memcpy(req->addr, &peer_addr, peer_addr_size);
-        req->fd = request_fd;
+        session_t *s = malloc(sizeof(session_t));
+        memset(s, 0, sizeof(session_t));
+        s->peer = peer;
+        s->addr = malloc(peer_addr_size);
+        memcpy(s->addr, &peer_addr, peer_addr_size);
+        s->fd = request_fd;
 
         void **handshake_data = malloc(2 * sizeof(void*));
         handshake_data[0] = m;
-        handshake_data[1] = req;
+        handshake_data[1] = s;
 
-        pthread_create(&req->thread, NULL, &peer_handshake, handshake_data);
-        pthread_detach(req->thread);
+        pthread_create(&s->thread, NULL, &peer_handshake, handshake_data);
+        pthread_detach(s->thread);
     }
 
     return NULL;
@@ -500,11 +460,10 @@ manager_new(const struct sockaddr_in6 *listen_addr)
 
     m->locator = locator_new();
 
-    m->sessions = malloc(m->locator->peers_size * sizeof(session_t*));
-    memset(m->sessions, 0, m->locator->peers_size * sizeof(session_t*));
-
-    m->requests = malloc(4 * sizeof(request_t*));
-    memset(m->sessions, 0, m->locator->peers_size * sizeof(session_t*));
+    m->sessions_size = 0;
+    m->sessions_capacity = 16;
+    m->sessions = malloc(m->sessions_capacity * sizeof(session_t*));
+    memset(m->sessions, 0, m->sessions_capacity * sizeof(session_t*));
 
     /* create listen socket */
     m->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
@@ -525,7 +484,6 @@ manager_new(const struct sockaddr_in6 *listen_addr)
         return NULL;
     }
 
-    char abuff[INET6_ADDRSTRLEN];
     DEBUG("started session manager, listening at [%s]:%d",
         sockaddr_str((struct sockaddr *)listen_addr),
         ntohs(listen_addr->sin6_port));
@@ -536,25 +494,27 @@ manager_new(const struct sockaddr_in6 *listen_addr)
 
 /* ===================== SESSION INITIATION ================================= */
 
-/** \brief Try to establish a TCP channel */
+/** \brief Try to establish a TCP channel
+ *
+ * \param arg Of type (void*){ manager_t *m, session_t *s }
+ */
 static void *
 connect_loop(void *arg)
 {
-    manager_t *m = ((void**)arg)[0];
-    request_t *req = ((void**)arg)[1];
+    session_t *s = ((void**)arg)[1];
+
     time_t connect_retry = 120;
 
-    int r = 0;
     while (1) {
-        request_change_state(m, req, STATE_CONNECT);
+        session_change_state(s, STATE_CONNECT);
 
-        int res = connect(req->fd,
-            (struct sockaddr*)req->addr,
+        int res = connect(s->fd,
+            (struct sockaddr*)s->addr,
             sizeof(struct sockaddr_in6));
 
         if (res < 0) {
             ERROR("connect(): %s", strerror(errno));
-            request_change_state(m, req, STATE_IDLE);
+            session_change_state(s, STATE_IDLE);
             sleep(connect_retry);
             if (connect_retry < MAX_BACKOFF_CONNECT_RETRY)
                 connect_retry *= 2;
@@ -575,8 +535,8 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
     uint32_t itad)
 {
     /* add peer to peer locator */
-    int idx = locator_add(manager->locator, addr, itad, manager->hold,
-        CAPINFO_TRANS_SEND_RECV);
+    const peer_t *peer = locator_add(manager->locator, addr, itad,
+        manager->hold, CAPINFO_TRANS_SEND_RECV);
     
     if (manager->sessions_size + 1 == manager->locator->peers_size) {
         manager->sessions = realloc(manager->sessions,
@@ -587,20 +547,30 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
     }
 
     /* create session request object and hand off to connect loop */
-    request_t *req = malloc(sizeof(request_t));
-    req->peer_idx = idx;
-    req->addr = malloc(sizeof(struct sockaddr_in6));
-    memcpy(req->addr, addr, sizeof(struct sockaddr_in6));
-    req->state = STATE_IDLE;
+    session_t *s = malloc(sizeof(session_t));
+    memset(s, 0, sizeof(session_t));
+    s->peer = peer;
+    s->addr = malloc(sizeof(struct sockaddr_in6));
+    memcpy(s->addr, addr, sizeof(struct sockaddr_in6));
+    s->state = STATE_IDLE;
 
-    req->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    /* add session to manager session vector */
+    if (manager->sessions_size + 1 > manager->sessions_capacity) {
+        manager->sessions = realloc(manager->sessions,
+            2 * sizeof(session_t) * manager->sessions_capacity);
+        manager->sessions_capacity *= 2;
+    }
+
+    manager->sessions[manager->sessions_size++] = s;
+
+    /* create socket and pass session to connect loop */
+    s->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
     
-
     void **connect_data = malloc(2 * sizeof(void*));
     connect_data[0] = manager;
-    connect_data[1] = req;
+    connect_data[1] = s;
 
-    pthread_create(&req->thread, NULL, &connect_loop, connect_data);
+    pthread_create(&s->thread, NULL, &connect_loop, connect_data);
 }
 
 void

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -58,6 +58,8 @@
 #endif /* MAX_BACKOFF_CONNECT_RETRY */
 
 
+static void *connect_loop(void *arg);
+
 
 /** \brief Lookup session by ITAD and ID match */
 static session_t *
@@ -78,7 +80,7 @@ static session_t *
 manager_session_lookup_peer(manager_t *m, const peer_t *peer)
 {
     for (size_t i = 0; i < m->sessions_size; i++)
-        if (m->sessions[i]->peer == peer)
+        if (m->sessions[i]->peer == peer && !m->sessions[i]->mark_stop_init)
         {
             return m->sessions[i];
         }
@@ -237,10 +239,9 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
 
     /* find old still initiating session pre-openconfirm if exists and stop it*/
     session_t *init_s = manager_session_lookup_peer(m, s->peer);
-    if (init_s) {
+    if (init_s && (init_s->initiated == 1) && (init_s != s)) {
         INFO("closing old initiating session");
-        session_shutdown(init_s);
-        manager_session_remove(m, init_s);
+        init_s->mark_stop_init = 1;
     }
 
 
@@ -248,7 +249,8 @@ handle_open(manager_t *m, session_t *s, const msg_t *msg,
     s->hold = MIN(s->peer->hold, open->open_hold);
 
     /* now add session to manager */
-    manager_session_add(m, s);
+    if (!s->initiated)
+        manager_session_add(m, s);
 
     size_t opts_toread = open->open_opts_len;
     const void *opt_cur = open->open_opts;
@@ -447,7 +449,7 @@ peer_handshake(void *arg)
 
             /* Hand newly established session off to session_loop */
             session_loop(arg);
-            return NULL;
+            connect_loop(arg);
         } break;
         default:
             ERROR("unexpected %s message");
@@ -576,11 +578,17 @@ manager_new(const struct sockaddr_in6 *listen_addr)
 static void *
 connect_loop(void *arg)
 {
+    manager_t *m = ((void**)arg)[0];
     session_t *s = ((void**)arg)[1];
 
     time_t connect_retry = 120;
 
     while (1) {
+        if (s->mark_stop_init) {
+            manager_session_remove(m, s);
+            return NULL;
+        }
+
         session_change_state(s, STATE_CONNECT);
 
         int res = connect(s->fd,
@@ -613,14 +621,6 @@ manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
     const peer_t *peer = locator_add(manager->locator, addr, itad,
         manager->hold, CAPINFO_TRANS_SEND_RECV);
     
-    if (manager->sessions_size + 1 == manager->locator->peers_size) {
-        manager->sessions = realloc(manager->sessions,
-            manager->locator->peers_size * sizeof(session_t*));
-    } else {
-        WARNING("manager session vector inconsistent with locator");
-        return;
-    }
-
     /* create session object and hand off to connect loop */
     session_t *s = malloc(sizeof(session_t));
     memset(s, 0, sizeof(session_t));

--- a/src/functions/manager.c
+++ b/src/functions/manager.c
@@ -139,7 +139,7 @@ handle_open(request_t *r, const peer_t *peer, const msg_t *msg, void *recv_wnd)
         return -1;
     }
 
-    /* TODO collision detection as per RFC
+    /* TODO: collision detection as per RFC
     if (manager_lookup_itad_id(s->itad, open->open_id)) {
         ERROR("peer ID exists in same ITAD");
         send_notification(s, NOTIF_CODE_ERROR_OPEN,
@@ -287,7 +287,7 @@ peer_handshake(void *arg)
     );
 
     SOCK_TRY_SEND(
-        send(req->fd, buff, res, 0) < 0,
+        send(req->fd, buff, res, 0),
         goto sock_error
     );
     request_change_state(req, STATE_OPENSENT);
@@ -319,7 +319,7 @@ peer_handshake(void *arg)
             );
 
             SOCK_TRY_SEND(
-                send(req->fd, buff, res, 0) < 0,
+                send(req->fd, buff, res, 0),
                 goto sock_error
             );
 

--- a/src/functions/manager.h
+++ b/src/functions/manager.h
@@ -34,6 +34,19 @@
 #include "locator.h"
 
 
+/** \brief Request object, represents connection before established state */
+typedef struct {
+    pthread_t               thread;
+    int                     peer_idx;
+    struct sockaddr_in6    *addr;
+    int                     fd;
+    session_state_t         state;
+
+    /* discovered */
+    uint32_t                id;
+    uint32_t                hold;
+} request_t;
+
 /** \brief Manager object */
 typedef struct {
     pthread_t   thread;
@@ -46,6 +59,8 @@ typedef struct {
 
     session_t **sessions;
     size_t      sessions_size;
+    request_t **requests;   /* TODO: save requests here */
+    size_t      requests_size;
 } manager_t;
 
 
@@ -57,8 +72,14 @@ void manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
     uint32_t itad);
 
 /** \brief Lookup session by ITAD and ID */
-session_t *manager_lookup_itad_id(manager_t manager, uint32_t itad,
+session_t *manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
     uint32_t id);
+
+/** \brief Lookup session by ID */
+session_t *manager_lookup_session_id(manager_t *manager, uint32_t id);
+
+/** \brief Lookup session by ID */
+request_t *manager_lookup_request_id(manager_t *manager, uint32_t id);
 
 /** \brief Run accept loop in thread */
 void manager_run(manager_t *manager);

--- a/src/functions/manager.h
+++ b/src/functions/manager.h
@@ -34,19 +34,6 @@
 #include "locator.h"
 
 
-/** \brief Request object, represents connection before established state */
-typedef struct {
-    pthread_t               thread;
-    int                     peer_idx;
-    struct sockaddr_in6    *addr;
-    int                     fd;
-    session_state_t         state;
-
-    /* discovered */
-    uint32_t                id;
-    uint32_t                hold;
-} request_t;
-
 /** \brief Manager object */
 typedef struct {
     pthread_t   thread;
@@ -58,9 +45,7 @@ typedef struct {
     locator_t  *locator;
 
     session_t **sessions;
-    size_t      sessions_size;
-    request_t **requests;   /* TODO: save requests here */
-    size_t      requests_size;
+    size_t      sessions_size, sessions_capacity;
 } manager_t;
 
 
@@ -77,9 +62,6 @@ session_t *manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
 
 /** \brief Lookup session by ID */
 session_t *manager_lookup_session_id(manager_t *manager, uint32_t id);
-
-/** \brief Lookup session by ID */
-request_t *manager_lookup_request_id(manager_t *manager, uint32_t id);
 
 /** \brief Run accept loop in thread */
 void manager_run(manager_t *manager);

--- a/src/functions/manager.h
+++ b/src/functions/manager.h
@@ -56,13 +56,6 @@ manager_t *manager_new(const struct sockaddr_in6 *listen_addr);
 void manager_add_peer(manager_t *manager, const struct sockaddr_in6 *addr,
     uint32_t itad);
 
-/** \brief Lookup session by ITAD and ID */
-session_t *manager_lookup_session_itad_id(manager_t *manager, uint32_t itad,
-    uint32_t id);
-
-/** \brief Lookup session by ID */
-session_t *manager_lookup_session_id(manager_t *manager, uint32_t id);
-
 /** \brief Run accept loop in thread */
 void manager_run(manager_t *manager);
 

--- a/src/functions/session.c
+++ b/src/functions/session.c
@@ -92,7 +92,7 @@ send_notification(int fd, int code, int subcode)
     );
 
     SOCK_TRY_SEND(
-        send(fd, buff, res, 0) < 0,
+        send(fd, buff, res, 0),
         goto sock_error
     );
 

--- a/src/functions/session.c
+++ b/src/functions/session.c
@@ -26,6 +26,8 @@
 
 #include "session.h"
 
+#include "manager.h"
+
 #include <logging/logging.h>
 #include <util/util.h>
 
@@ -58,7 +60,7 @@ session_str(session_t *s)
     snprintf(str, 256, "(%s):%d:%s",
         inet_ntop(AF_INET6, &s->addr->sin6_addr, abuff,
             sizeof(abuff)),
-        s->peer_itad,
+        s->peer->itad,
         inet_ntop(AF_INET, &s->peer_id, abuff2, sizeof(abuff2)));
     return str;
 }
@@ -71,7 +73,7 @@ id_str(uint32_t id)
     return idbuff;
 }
 
-static void
+void
 session_change_state(session_t *s, session_state_t new_state)
 {
     DEBUG("peer session %s changed state from %s to %s", session_str(s),
@@ -124,11 +126,16 @@ send_notification_res(int fd, int res)
     return 0;
 }
 
-
+/** \brief Session loop
+ *
+ * \param arg Of type (void*){ manager_t *m, session_t *s }
+ */
 void *
 session_loop(void *arg)
 {
-    session_t *s = arg;
+    manager_t *m = ((void**)arg)[0];
+    session_t *s = ((void**)arg)[1];
+    free(arg);
 
     int res = 0, toread = 0;
     char buff[MAX_MSG_SIZE];

--- a/src/functions/session.c
+++ b/src/functions/session.c
@@ -135,7 +135,6 @@ session_loop(void *arg)
 {
     manager_t *m = ((void**)arg)[0];
     session_t *s = ((void**)arg)[1];
-    free(arg);
 
     int res = 0, toread = 0;
     char buff[MAX_MSG_SIZE];

--- a/src/functions/session.h
+++ b/src/functions/session.h
@@ -89,6 +89,7 @@ typedef struct {
     pthread_t               thread;
     session_state_t         state;
     int                     initiated; /**< Initiated by local */
+    int                     mark_stop_init; /**< Tell initiating thread to quit*/
 
     uint16_t                hold;
 

--- a/src/functions/session.h
+++ b/src/functions/session.h
@@ -27,6 +27,7 @@
 #ifndef _SESSION_H
 #define _SESSION_H
 
+#include "locator.h"
 #include <protocol/protocol.h>
 
 #include <netinet/in.h>
@@ -87,18 +88,18 @@ extern const char *session_state_strs[];
 typedef struct {
     pthread_t               thread;
     session_state_t         state;
-    uint32_t                itad, id;
     uint16_t                hold;
-
-    capinfo_transmode_t     transmode;
 
     struct sockaddr_in6    *addr;
     int                     fd;
 
-    uint32_t                peer_itad, peer_id;
+    const peer_t           *peer;
+    uint32_t                peer_id;
 } session_t;
 
 
+/** \brief Change session state */
+void session_change_state(session_t *s, session_state_t new_state);
 
 /** \brief Send notification helper */
 int send_notification(int fd, int code, int subcode);

--- a/src/functions/session.h
+++ b/src/functions/session.h
@@ -88,6 +88,8 @@ extern const char *session_state_strs[];
 typedef struct {
     pthread_t               thread;
     session_state_t         state;
+    int                     initiated; /**< Initiated by local */
+
     uint16_t                hold;
 
     struct sockaddr_in6    *addr;

--- a/src/functions/session.h
+++ b/src/functions/session.h
@@ -48,7 +48,7 @@
  * \param fd Socket
  * \param buff Receive buffer
  * \param type Typename to receive
- * \param ation Error condition action
+ * \param action Error condition action
  */
 #define SOCK_TRY_RECV(fd, buff, type, action) \
     toread = sizeof(type); \

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -53,3 +53,12 @@ sockaddr_str(const struct sockaddr *sa)
     return addr_buff;
 }
 
+const char *
+sockaddr6_str(const struct sockaddr_in6 *sa)
+{
+    static char addr_buff[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &((struct sockaddr_in6 *)sa)->sin6_addr, addr_buff,
+        INET6_ADDRSTRLEN);
+    return addr_buff;
+}
+

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -29,4 +29,7 @@ void map_addr_inet_inet6(struct sockaddr_in6 *sin6,
 
 const char *sockaddr_str(const struct sockaddr *sa);
 
+const char *sockaddr6_str(const struct sockaddr_in6 *sa);
+
 #endif /* _UTIL_H */
+


### PR DESCRIPTION
- [x] Lookup colliding session
- [x] Established session collision resolution -> close new connection always
- [x] ~~Lookup colliding pre-session establishment requests~~
- [x] Pre-establishment collision resolution -> close connection with lower ID in same ITAD or lower ITAD
- [x] Send Cease notification before closing
- [x] Stop trying to connect when incoming session is accepted
- [x] Reenter connect_loop if session falls to idle from established
